### PR TITLE
unlink local libraries from linux build script

### DIFF
--- a/linux_build.sh
+++ b/linux_build.sh
@@ -1,2 +1,2 @@
 #! /bin/sh
-bear -- g++ -std=c++17 -g -Wall src/glad.c src/imgui/*.cpp src/*.cpp -o 3dco -I include -I src/imgui -L lib -lglfw -lSDL2 -lGL -ldl
+bear -- g++ -std=c++17 -g -Wall src/glad.c src/imgui/*.cpp src/*.cpp -o 3dco -I include -I src/imgui -lglfw -lSDL2 -lGL -ldl


### PR DESCRIPTION
This flag would link the files in the lib folder, causing the build to fail, removing it allows it to use the system libraries and compile correctly