### PR TITLE
remove extra puntuation in mapping file

### DIFF
--- a/src/settings_window.cpp
+++ b/src/settings_window.cpp
@@ -1287,7 +1287,6 @@ void drawSettingsWindow(){
 						open_ofstream(path);
 						//char* mapping = SDL_GameControllerMapping(getControllerWindow(tabs[selected_tab].ID)->sdl_controller);
 						std::string mapping = "";
-						mapping.append(",");
 						for(int i = 0; i < 27; i++){
 							if (current_mapping[i] != ""){
 								mapping.append(mapping_names[i]);


### PR DESCRIPTION
this "," at the beginning of the string was also being appended by the load function, breaking the formatting and causing a segfault, removing either one fixes the issue and allows loading previously saved mappings