### PR TITLE
Enable OpenGL Anti-Aliasing

### DIFF
--- a/src/controller_window.cpp
+++ b/src/controller_window.cpp
@@ -48,13 +48,17 @@ std::vector<controller_window> windows;
 
 void createControllerWindow(std::string title, std::string model_path){
     controller_window w;
-	
-	w.glfw_window = glfwCreateWindow(defaultWidth, defaultHeight, title.c_str(), NULL, NULL);
+
+    // Set number of samples for multi-sampling
+    glfwWindowHint(GLFW_SAMPLES, 4);
+    w.glfw_window = glfwCreateWindow(defaultWidth, defaultHeight, title.c_str(), NULL, NULL);
     if (w.glfw_window == NULL){
         std::cout << "Failed to create controller indow" << std::endl;
         glfwTerminate();
     }
     glfwMakeContextCurrent(w.glfw_window);
+    // Enable multi-sampling
+    glEnable(GL_MULTISAMPLE);
 
 	GLFWimage images[1]; 
 	images[0].pixels = stbi_load("icon.png", &images[0].width, &images[0].height, 0, 4);


### PR DESCRIPTION
Using the fairly simple https://learnopengl.com/Advanced-OpenGL/Anti-Aliasing instructions we add anti-aliasing to stop the controllers from being so jagged.

Before:
![image](https://github.com/user-attachments/assets/333f7caa-eef9-4257-8186-7505a4031cb1)


After:
![image](https://github.com/user-attachments/assets/a7ede42e-c414-4b96-a1a2-3d82555a430e)
